### PR TITLE
fix(security): add Permissions-Policy, X-XSS-Protection, and X-DNS-Prefetch-Control headers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -66,6 +66,30 @@ const nextConfig = {
             key: "Strict-Transport-Security",
             value: "max-age=63072000; includeSubDomains; preload",
           },
+          // Prevents browsers from sending the Referer header to cross-origin requests
+          {
+            key: "X-DNS-Prefetch-Control",
+            value: "on",
+          },
+          // Restricts access to browser features/APIs
+          {
+            key: "Permissions-Policy",
+            value: [
+              "camera=()",
+              "microphone=()",
+              "geolocation=()",
+              "browsing-topics=()",
+              "interest-cohort=()",
+              "payment=(self)",
+              "usb=()",
+              "bluetooth=()",
+            ].join(", "),
+          },
+          // Legacy XSS protection for older browsers
+          {
+            key: "X-XSS-Protection",
+            value: "1; mode=block",
+          },
         ],
       },
     ];


### PR DESCRIPTION
## Summary

Closes #24

`next.config.mjs` already had a solid security foundation (CSP, X-Frame-Options, HSTS, X-Content-Type-Options, Referrer-Policy) but was missing three headers recommended by security best practices.

## Changes

### `next.config.mjs`

Added 3 missing security headers:

**`Permissions-Policy`** — restricts access to browser features/APIs:
- Disables: camera, microphone, geolocation, browsing-topics, interest-cohort, usb, bluetooth
- Allows: `payment=(self)` to support Stellar wallet interactions

**`X-XSS-Protection: 1; mode=block`** — legacy XSS protection for older browsers that do not support CSP

**`X-DNS-Prefetch-Control: on`** — enables DNS prefetching for improved page load performance

All existing headers preserved unchanged:
- Content-Security-Policy (with production/dev toggle for `unsafe-eval`)
- X-Frame-Options: DENY
- X-Content-Type-Options: nosniff
- Referrer-Policy: strict-origin-when-cross-origin
- Strict-Transport-Security: max-age=63072000 with preload

## Validation
All 8 security headers verified present via Node.js script check.