### PR TITLE
fix: add authorization to set_risk_tier (Issue #24)

### DIFF
--- a/risk_score/Cargo.lock
+++ b/risk_score/Cargo.lock
@@ -30,6 +30,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "ark-bls12-381"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +296,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +402,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1054,6 +1084,7 @@ version = "22.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "027cd856171bfd6ad2c0ffb3b7dfe55ad7080fb3050c36ad20970f80da634472"
 dependencies = [
+ "arbitrary",
  "crate-git-revision",
  "ethnum",
  "num-derive",
@@ -1147,7 +1178,11 @@ version = "22.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7ac27d7573e62b745513fa1be8dab7a09b9676a7f39db97164f1d458a344749"
 dependencies = [
+ "arbitrary",
  "bytes-lit",
+ "ctor",
+ "derive_arbitrary",
+ "ed25519-dalek",
  "rand",
  "rustc_version",
  "serde",
@@ -1259,6 +1294,7 @@ version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ce69db907e64d1e70a3dce8d4824655d154749426a6132b25395c49136013e4"
 dependencies = [
+ "arbitrary",
  "base64 0.13.1",
  "crate-git-revision",
  "escape-bytes",

--- a/risk_score/Cargo.toml
+++ b/risk_score/Cargo.toml
@@ -9,6 +9,9 @@ crate-type = ["cdylib"]
 [dependencies]
 soroban-sdk = "22.0.8"
 
+[dev-dependencies]
+soroban-sdk = { version = "22.0.8", features = ["testutils"] }
+
 [profile.release]
 opt-level = "z"
 overflow-checks = true

--- a/risk_score/src/lib.rs
+++ b/risk_score/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Map, Symbol, Vec};
 
+/// Storage key for the admin address
+const ADMIN_KEY: &str = "admin";
+
 /// Enhanced Risk & Tier Management Contract
 /// Stores risk scores with tier classifications and timestamps
 #[contract]
@@ -18,9 +21,47 @@ pub struct RiskTierData {
 
 #[contractimpl]
 impl RiskTierContract {
-    /// Set risk score with tier classification and timestamp
-    /// Following Soroban persistent storage best practices with tuple keys
-    pub fn set_risk_tier(env: Env, user: Address, score: u32, tier: Symbol, chosen_tier: Symbol) {
+    /// Initialize the contract with a trusted admin address.
+    /// Can only be called once — panics if already initialized.
+    pub fn initialize(env: Env, admin: Address) {
+        let key = Symbol::new(&env, ADMIN_KEY);
+        if env.storage().instance().has(&key) {
+            panic!("Contract already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&key, &admin);
+    }
+
+    /// Get the admin address (returns None if not initialized)
+    pub fn get_admin(env: Env) -> Option<Address> {
+        let key = Symbol::new(&env, ADMIN_KEY);
+        env.storage().instance().get(&key)
+    }
+
+    /// Set risk score with tier classification and timestamp.
+    /// Requires caller to be admin OR the user themselves.
+    pub fn set_risk_tier(
+        env: Env,
+        caller: Address,
+        user: Address,
+        score: u32,
+        tier: Symbol,
+        chosen_tier: Symbol,
+    ) {
+        // Authorization: caller must authenticate
+        caller.require_auth();
+
+        // Caller must be admin or the user themselves
+        if caller != user {
+            let admin_key = Symbol::new(&env, ADMIN_KEY);
+            let admin: Address = env
+                .storage()
+                .instance()
+                .get(&admin_key)
+                .expect("Contract not initialized");
+            assert!(caller == admin, "Unauthorized: caller must be admin or the user");
+        }
+
         // Validate inputs
         assert!(score <= 100, "Score must be 0-100");
         assert!(
@@ -112,8 +153,12 @@ impl RiskTierContract {
             .unwrap_or(Vec::new(&env))
     }
 
-    /// Update user's chosen tier (risk-based validation)
+    /// Update user's chosen tier (risk-based validation).
+    /// Only the user themselves can update their chosen tier.
     pub fn update_chosen_tier(env: Env, user: Address, new_chosen_tier: Symbol) {
+        // Authorization: only the user can update their own chosen tier
+        user.require_auth();
+
         let tuple_key = (user.clone(), Symbol::new(&env, "risk_tier"));
 
         if let Some(mut risk_data) = env
@@ -196,17 +241,124 @@ mod tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, Env};
 
-    #[test]
-    fn test_set_and_get_risk_tier() {
+    // =====================================================
+    // Helper: set up env + client + admin, initialize contract
+    // =====================================================
+    fn setup() -> (Env, RiskTierContractClient<'static>, Address) {
         let env = Env::default();
+        env.mock_all_auths();
         let contract_id = env.register_contract(None, RiskTierContract);
         let client = RiskTierContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        (env, client, admin)
+    }
 
+    // =====================================================
+    // Initialize tests
+    // =====================================================
+
+    #[test]
+    fn test_initialize_sets_admin() {
+        let (env, client, admin) = setup();
+        let _ = env;
+        assert_eq!(client.get_admin().unwrap(), admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Contract already initialized")]
+    fn test_initialize_cannot_be_called_twice() {
+        let (env, client, _admin) = setup();
+        let another = Address::generate(&env);
+        client.initialize(&another);
+    }
+
+    // =====================================================
+    // Authorization tests for set_risk_tier
+    // =====================================================
+
+    #[test]
+    fn test_admin_can_set_any_users_risk_tier() {
+        let (env, client, admin) = setup();
         let user = Address::generate(&env);
         let tier_1 = Symbol::new(&env, "TIER_1");
-        
-        client.set_risk_tier(&user, &25, &tier_1, &tier_1);
-        
+
+        client.set_risk_tier(&admin, &user, &25, &tier_1, &tier_1);
+
+        let risk_data = client.get_risk_tier(&user).unwrap();
+        assert_eq!(risk_data.score, 25);
+        assert_eq!(risk_data.tier, tier_1);
+    }
+
+    #[test]
+    fn test_user_can_set_own_risk_tier() {
+        let (env, client, _admin) = setup();
+        let user = Address::generate(&env);
+        let tier_2 = Symbol::new(&env, "TIER_2");
+
+        client.set_risk_tier(&user, &user, &50, &tier_2, &tier_2);
+
+        let risk_data = client.get_risk_tier(&user).unwrap();
+        assert_eq!(risk_data.score, 50);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized: caller must be admin or the user")]
+    fn test_random_address_cannot_set_another_users_tier() {
+        let (env, client, _admin) = setup();
+        let attacker = Address::generate(&env);
+        let victim = Address::generate(&env);
+        let tier_1 = Symbol::new(&env, "TIER_1");
+
+        client.set_risk_tier(&attacker, &victim, &99, &tier_1, &tier_1);
+    }
+
+    #[test]
+    fn test_admin_can_overwrite_user_score() {
+        let (env, client, admin) = setup();
+        let user = Address::generate(&env);
+        let tier_1 = Symbol::new(&env, "TIER_1");
+        let tier_3 = Symbol::new(&env, "TIER_3");
+
+        // User sets own score
+        client.set_risk_tier(&user, &user, &20, &tier_1, &tier_1);
+        assert_eq!(client.get_score(&user), 20);
+
+        // Admin overwrites it
+        client.set_risk_tier(&admin, &user, &80, &tier_3, &tier_3);
+        assert_eq!(client.get_score(&user), 80);
+    }
+
+    // =====================================================
+    // Authorization tests for update_chosen_tier
+    // =====================================================
+
+    #[test]
+    fn test_user_can_update_own_chosen_tier() {
+        let (env, client, admin) = setup();
+        let user = Address::generate(&env);
+        let tier_1 = Symbol::new(&env, "TIER_1");
+        let tier_2 = Symbol::new(&env, "TIER_2");
+
+        client.set_risk_tier(&admin, &user, &25, &tier_1, &tier_1);
+        client.update_chosen_tier(&user, &tier_2);
+
+        let chosen = client.get_chosen_tier(&user);
+        assert_eq!(chosen, tier_2);
+    }
+
+    // =====================================================
+    // Original functional tests (updated with caller param)
+    // =====================================================
+
+    #[test]
+    fn test_set_and_get_risk_tier() {
+        let (env, client, admin) = setup();
+        let user = Address::generate(&env);
+        let tier_1 = Symbol::new(&env, "TIER_1");
+
+        client.set_risk_tier(&admin, &user, &25, &tier_1, &tier_1);
+
         let risk_data = client.get_risk_tier(&user).unwrap();
         assert_eq!(risk_data.score, 25);
         assert_eq!(risk_data.tier, tier_1);
@@ -215,15 +367,12 @@ mod tests {
 
     #[test]
     fn test_score_validation_upper_bound() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user = Address::generate(&env);
         let tier_3 = Symbol::new(&env, "TIER_3");
-        
-        client.set_risk_tier(&user, &100, &tier_3, &tier_3);
-        
+
+        client.set_risk_tier(&admin, &user, &100, &tier_3, &tier_3);
+
         let score = client.get_score(&user);
         assert_eq!(score, 100);
     }
@@ -231,130 +380,103 @@ mod tests {
     #[test]
     #[should_panic(expected = "Score must be 0-100")]
     fn test_score_validation_exceeds_limit() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user = Address::generate(&env);
         let tier_3 = Symbol::new(&env, "TIER_3");
-        
-        client.set_risk_tier(&user, &101, &tier_3, &tier_3);
+
+        client.set_risk_tier(&admin, &user, &101, &tier_3, &tier_3);
     }
 
     #[test]
     #[should_panic(expected = "Invalid tier")]
     fn test_invalid_tier_validation() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user = Address::generate(&env);
         let invalid_tier = Symbol::new(&env, "TIER_4");
-        
-        client.set_risk_tier(&user, &50, &invalid_tier, &invalid_tier);
+
+        client.set_risk_tier(&admin, &user, &50, &invalid_tier, &invalid_tier);
     }
 
     #[test]
     fn test_tier_access_tier1_low_risk() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user = Address::generate(&env);
         let tier_1 = Symbol::new(&env, "TIER_1");
-        
-        client.set_risk_tier(&user, &25, &tier_1, &tier_1);
-        
+
+        client.set_risk_tier(&admin, &user, &25, &tier_1, &tier_1);
+
         assert!(client.can_access_tier(&user, &tier_1));
     }
 
     #[test]
     fn test_tier_access_tier1_boundary() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user = Address::generate(&env);
         let tier_1 = Symbol::new(&env, "TIER_1");
-        
-        client.set_risk_tier(&user, &30, &tier_1, &tier_1);
-        
+
+        client.set_risk_tier(&admin, &user, &30, &tier_1, &tier_1);
+
         assert!(client.can_access_tier(&user, &tier_1));
     }
 
     #[test]
     fn test_tier_access_tier1_denied() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user = Address::generate(&env);
         let tier_2 = Symbol::new(&env, "TIER_2");
         let tier_1 = Symbol::new(&env, "TIER_1");
-        
-        client.set_risk_tier(&user, &50, &tier_2, &tier_2);
-        
+
+        client.set_risk_tier(&admin, &user, &50, &tier_2, &tier_2);
+
         assert!(!client.can_access_tier(&user, &tier_1));
     }
 
     #[test]
     fn test_tier_access_tier2_medium_risk() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user = Address::generate(&env);
         let tier_2 = Symbol::new(&env, "TIER_2");
-        
-        client.set_risk_tier(&user, &50, &tier_2, &tier_2);
-        
+
+        client.set_risk_tier(&admin, &user, &50, &tier_2, &tier_2);
+
         assert!(client.can_access_tier(&user, &tier_2));
     }
 
     #[test]
     fn test_tier_access_tier3_always_accessible() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user = Address::generate(&env);
         let tier_3 = Symbol::new(&env, "TIER_3");
-        
-        client.set_risk_tier(&user, &85, &tier_3, &tier_3);
-        
+
+        client.set_risk_tier(&admin, &user, &85, &tier_3, &tier_3);
+
         assert!(client.can_access_tier(&user, &tier_3));
     }
 
     #[test]
     fn test_get_tier_users() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user1 = Address::generate(&env);
         let user2 = Address::generate(&env);
         let tier_1 = Symbol::new(&env, "TIER_1");
-        
-        client.set_risk_tier(&user1, &20, &tier_1, &tier_1);
-        client.set_risk_tier(&user2, &25, &tier_1, &tier_1);
-        
+
+        client.set_risk_tier(&admin, &user1, &20, &tier_1, &tier_1);
+        client.set_risk_tier(&admin, &user2, &25, &tier_1, &tier_1);
+
         let tier_users = client.get_tier_users(&tier_1);
         assert_eq!(tier_users.len(), 2);
     }
 
     #[test]
     fn test_update_chosen_tier_valid() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user = Address::generate(&env);
         let tier_1 = Symbol::new(&env, "TIER_1");
         let tier_2 = Symbol::new(&env, "TIER_2");
-        
-        client.set_risk_tier(&user, &25, &tier_1, &tier_1);
+
+        client.set_risk_tier(&admin, &user, &25, &tier_1, &tier_1);
         client.update_chosen_tier(&user, &tier_2);
-        
+
         let chosen = client.get_chosen_tier(&user);
         assert_eq!(chosen, tier_2);
     }
@@ -362,36 +484,30 @@ mod tests {
     #[test]
     #[should_panic(expected = "High risk users can only access TIER_3")]
     fn test_update_chosen_tier_high_risk_restriction() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user = Address::generate(&env);
         let tier_3 = Symbol::new(&env, "TIER_3");
         let tier_1 = Symbol::new(&env, "TIER_1");
-        
-        client.set_risk_tier(&user, &85, &tier_3, &tier_3);
+
+        client.set_risk_tier(&admin, &user, &85, &tier_3, &tier_3);
         client.update_chosen_tier(&user, &tier_1);
     }
 
     #[test]
     fn test_get_tier_stats() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user1 = Address::generate(&env);
         let user2 = Address::generate(&env);
         let user3 = Address::generate(&env);
-        
+
         let tier_1 = Symbol::new(&env, "TIER_1");
         let tier_2 = Symbol::new(&env, "TIER_2");
         let tier_3 = Symbol::new(&env, "TIER_3");
-        
-        client.set_risk_tier(&user1, &20, &tier_1, &tier_1);
-        client.set_risk_tier(&user2, &50, &tier_2, &tier_2);
-        client.set_risk_tier(&user3, &80, &tier_3, &tier_3);
-        
+
+        client.set_risk_tier(&admin, &user1, &20, &tier_1, &tier_1);
+        client.set_risk_tier(&admin, &user2, &50, &tier_2, &tier_2);
+        client.set_risk_tier(&admin, &user3, &80, &tier_3, &tier_3);
+
         let stats = client.get_tier_stats();
         assert_eq!(stats.get(tier_1).unwrap(), 1);
         assert_eq!(stats.get(tier_2).unwrap(), 1);
@@ -400,17 +516,14 @@ mod tests {
 
     #[test]
     fn test_score_update_overwrites_previous() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user = Address::generate(&env);
         let tier_2 = Symbol::new(&env, "TIER_2");
         let tier_1 = Symbol::new(&env, "TIER_1");
-        
-        client.set_risk_tier(&user, &50, &tier_2, &tier_2);
-        client.set_risk_tier(&user, &25, &tier_1, &tier_1);
-        
+
+        client.set_risk_tier(&admin, &user, &50, &tier_2, &tier_2);
+        client.set_risk_tier(&admin, &user, &25, &tier_1, &tier_1);
+
         let risk_data = client.get_risk_tier(&user).unwrap();
         assert_eq!(risk_data.score, 25);
         assert_eq!(risk_data.tier, tier_1);
@@ -418,46 +531,37 @@ mod tests {
 
     #[test]
     fn test_no_risk_data_returns_zero_score() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
+        let (_env, client, _admin) = setup();
+        let user = Address::generate(&_env);
 
-        let user = Address::generate(&env);
-        
         let score = client.get_score(&user);
         assert_eq!(score, 0);
     }
 
     #[test]
     fn test_no_risk_data_denies_tier_access() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
+        let (_env, client, _admin) = setup();
+        let user = Address::generate(&_env);
+        let tier_3 = Symbol::new(&_env, "TIER_3");
 
-        let user = Address::generate(&env);
-        let tier_3 = Symbol::new(&env, "TIER_3");
-        
         assert!(!client.can_access_tier(&user, &tier_3));
     }
 
     #[test]
     fn test_multiple_users_different_tiers() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, RiskTierContract);
-        let client = RiskTierContractClient::new(&env, &contract_id);
-
+        let (env, client, admin) = setup();
         let user1 = Address::generate(&env);
         let user2 = Address::generate(&env);
         let user3 = Address::generate(&env);
-        
+
         let tier_1 = Symbol::new(&env, "TIER_1");
         let tier_2 = Symbol::new(&env, "TIER_2");
         let tier_3 = Symbol::new(&env, "TIER_3");
-        
-        client.set_risk_tier(&user1, &15, &tier_1, &tier_1);
-        client.set_risk_tier(&user2, &45, &tier_2, &tier_2);
-        client.set_risk_tier(&user3, &90, &tier_3, &tier_3);
-        
+
+        client.set_risk_tier(&admin, &user1, &15, &tier_1, &tier_1);
+        client.set_risk_tier(&admin, &user2, &45, &tier_2, &tier_2);
+        client.set_risk_tier(&admin, &user3, &90, &tier_3, &tier_3);
+
         assert!(client.can_access_tier(&user1, &tier_1));
         assert!(!client.can_access_tier(&user2, &tier_1));
         assert!(client.can_access_tier(&user2, &tier_2));

--- a/src/app/lib/writeScore.js
+++ b/src/app/lib/writeScore.js
@@ -97,12 +97,14 @@ export async function writeScoreToBlockchain({
     // Debug ScVal conversion
 
     // Create the contract call operation with proper ScVal conversion
-    // Using the actual contract method: set_risk_tier(user, score, tier, chosen_tier)
+    // Using the actual contract method: set_risk_tier(caller, user, score, tier, chosen_tier)
+    // The caller is the user themselves (self-service auth)
     let operation;
     try {
       operation = contract.call(
         "set_risk_tier",
-        Address.fromString(address).toScVal(),
+        Address.fromString(address).toScVal(), // caller
+        Address.fromString(address).toScVal(), // user (same as caller for self-service)
         nativeToScVal(Math.round(score), { type: "u32" }),
         nativeToScVal(tier, { type: "symbol" }),
         nativeToScVal(validateTier(chosenTierName), { type: "symbol" })

--- a/src/lib/riskTierClient.ts
+++ b/src/lib/riskTierClient.ts
@@ -202,26 +202,30 @@ export class RiskTierContractClient {
 
   /**
    * Set risk score with tier classification.
-   * Maps to Rust: `set_risk_tier(user, score, tier, chosen_tier)`
+   * Maps to Rust: `set_risk_tier(caller, user, score, tier, chosen_tier)`
    *
-   * @param userAddress - Stellar G... or C... address
-   * @param score       - Risk score 0-100
-   * @param tier        - Calculated tier (TIER_1 | TIER_2 | TIER_3)
-   * @param chosenTier  - User's chosen tier
+   * @param callerAddress - Stellar address of the caller (admin or user)
+   * @param userAddress   - Stellar G... or C... address of the target user
+   * @param score         - Risk score 0-100
+   * @param tier          - Calculated tier (TIER_1 | TIER_2 | TIER_3)
+   * @param chosenTier    - User's chosen tier
    * @returns Transaction hash
    */
   async setRiskTier(
+    callerAddress: string,
     userAddress: string,
     score: number,
     tier: TierLevel,
     chosenTier: TierLevel
   ): Promise<string> {
+    const callerAddr = validateAddress(callerAddress, "Caller address");
     const addr = validateAddress(userAddress, "User address");
     const safeScore = validateScore(score);
     const safeTier = validateTierInput(tier, "Tier");
     const safeChosen = validateTierInput(chosenTier, "Chosen tier");
 
-    const xdr = await this.buildWriteTransaction(addr, "set_risk_tier", [
+    const xdr = await this.buildWriteTransaction(callerAddr, "set_risk_tier", [
+      Address.fromString(callerAddr).toScVal(),
       Address.fromString(addr).toScVal(),
       nativeToScVal(safeScore, { type: "u32" }),
       nativeToScVal(safeTier, { type: "symbol" }),
@@ -660,6 +664,7 @@ export function useRiskTierContract() {
   const [error, setError] = useState<string | null>(null);
 
   const setRiskTier = async (
+    callerAddress: string,
     userAddress: string,
     score: number,
     tier: TierLevel,
@@ -669,6 +674,7 @@ export function useRiskTierContract() {
       setLoading(true);
       setError(null);
       return await riskTierClient.setRiskTier(
+        callerAddress,
         userAddress,
         score,
         tier,


### PR DESCRIPTION
## Summary

- **`initialize(admin)`** — one-time function to set a trusted admin address, stored in instance storage. Panics on double-init.
- **`set_risk_tier`** — now takes a `caller` parameter. `caller.require_auth()` is enforced, and if `caller != user`, the caller must be the admin. Random addresses are blocked from manipulating other users' scores.
- **`update_chosen_tier`** — now requires `user.require_auth()` so only the user can change their own chosen tier.
- **TypeScript client & writeScore.js** updated to pass the new `caller` parameter.
- **24/24 unit tests passing**, covering:
  - Admin init & double-init rejection
  - Admin setting any user's tier
  - User setting their own tier (self-service)
  - Unauthorized caller blocked
  - Admin overwriting user score
  - All original functional tests preserved

## Test plan

- [x] `cargo test` — 24/24 passing
- [ ] Verify TypeScript client integration on testnet
- [ ] Verify `writeScore.js` self-service flow works end-to-end

Closes #24