### PR TITLE
fix(riskTierClient): remove erroneous horizonServer constant and clos…

### DIFF
--- a/src/lib/riskTierClient.ts
+++ b/src/lib/riskTierClient.ts
@@ -26,7 +26,8 @@ import { getCache, setCache, invalidateCache } from "./cacheManager";
 import { dispatchCacheEvent } from "../hooks/useCacheInvalidation";
 import { CACHE_KEYS } from "../types/cache";
 
-const horizonServer = new Server("https://horizon-testnet.stellar.org");
+// NOTE: Horizon account loading is handled inside resolveSourceAccount() using
+// Horizon.Server directly. A module-level horizonServer constant is not needed.
 
 // ─── Type Definitions ──────────────────────────────────────────────
 
@@ -150,6 +151,7 @@ const RISK_TIER_CACHE_TTL = 15 * 60 * 1000; // 15 minutes for risk tier data
  * Type-Safe Risk Tier Contract Client
  * Following Soroban CLI TypeScript bindings pattern
  * Enhanced with intelligent caching
+ */
 // ─── Contract Client (Fixes #16) ──────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Two bugs fixed in `src/lib/riskTierClient.ts`:

### Bug 1 ## Summary

Two bugs fixed in `src/lib/riskTierClient.ts`:

### Bug 1 - Wrong server class used for `horizonServer`

`horizonServer` on line 29 was instantiated with the Soroban RPC `Server` class (imported from `@stellar/stellar-sdk/rpc`), **not** with `Horizon.Server`. This would return incorrect data if the variable were ever used for Horizon account queries. Since the variable is also unused (account loading already happens correctly inside `resolveSourceAccount()` via a local `new Horizon.Server(...)` call), it has been removed entirely to prevent future misuse.

### Bug 2 - Unclosed JSDoc comment block

The JSDoc block starting at line 149 was never closed - the `*/` was missing before the `// --- Contract Client` section separator. This caused TypeScript (in strict mode) and all documentation generators to parse the next `/** ... */` block as a continuation of the same malformed comment. The missing `*/` has been added.

## Files Changed
- `src/lib/riskTierClient.ts`
## Testing
- Confirm TypeScript compiles without errors: `npx tsc --noEmit`