### PR TITLE
fix(rateLimiter): await async checkRateLimit in getAllRateLimits + ad…

### DIFF
--- a/src/lib/rateLimiter.js
+++ b/src/lib/rateLimiter.js
@@ -50,6 +50,16 @@ export async function checkRateLimit(walletAddress) {
     }
 
     // Fallback to legacy localStorage check for migration
+    // Guard against SSR environments where localStorage is not available
+    if (typeof localStorage === 'undefined') {
+      return {
+        canUpdate: true,
+        remainingTime: 0,
+        lastUpdate: null,
+        nextUpdateTime: null,
+      };
+    }
+
     const lastUpdateKey = `risk_score_last_update_${walletAddress}`;
     const lastUpdate = localStorage.getItem(lastUpdateKey);
 
@@ -189,8 +199,10 @@ export async function clearRateLimit(walletAddress) {
 /**
  * Get all rate limited wallets (for debugging)
  */
-export function getAllRateLimits() {
+export async function getAllRateLimits() {
   try {
+    if (typeof localStorage === 'undefined') return [];
+
     const rateLimits = [];
 
     for (let i = 0; i < localStorage.length; i++) {
@@ -198,7 +210,8 @@ export function getAllRateLimits() {
       if (key && key.startsWith("risk_score_last_update_")) {
         const walletAddress = key.replace("risk_score_last_update_", "");
         const lastUpdate = parseInt(localStorage.getItem(key));
-        const status = checkRateLimit(walletAddress);
+        // checkRateLimit is async — must be awaited to get the resolved value
+        const status = await checkRateLimit(walletAddress);
 
         rateLimits.push({
           walletAddress,


### PR DESCRIPTION
## Summary

Two bugs fixed in `src/lib/rateLimiter.js`:

### Bug 1 - Unawaited async call in `getAllRateLimits()`

`getAllRateLimits()` called `checkRateLimit(walletAddress)` - an **async** function - without `await`. This meant each `status` field in the returned array held a raw `Promise` object rather than the resolved value. Callers would see `{ status: Promise { <pending> } }` instead of useful rate-limit data. The function is now `async` and properly `await`s each call.

### Bug 2 - Missing SSR guard causes `ReferenceError` in Next.js

The fallback `localStorage.getItem(...)` call inside `checkRateLimit()` had no `typeof localStorage !== 'undefined'` guard. On server-side renders this throws `ReferenceError: localStorage is not defined`, crashing the Next.js middleware or any server component that imports this module. A guard and safe default return value have been added.

The same guard was added to `getAllRateLimits()` for consistency.

## Files Changed
- `src/lib/rateLimiter.js`
## Testing
- Call `getAllRateLimits()` - it should now return an array of resolved objects, not Promises.
- - Render a page server-side - no `ReferenceError` should be thrown.