### PR TITLE
fix(lightweightRiskModel): fix duplicate quality check and add null g…

### DIFF
--- a/src/lib/lightweightRiskModel.js
+++ b/src/lib/lightweightRiskModel.js
@@ -41,6 +41,11 @@ const NORMALIZATION = {
  * @returns {Object} Risk analysis result
  */
 export function calculateRiskScore(metrics) {
+  if (!metrics || typeof metrics !== 'object') {
+    console.error('calculateRiskScore: metrics must be a non-null object');
+    return fallbackRiskCalculation({});
+  }
+
   try {
     // Normalize features to 0-1 range
     const normalizedFeatures = normalizeFeatures(metrics);
@@ -295,7 +300,11 @@ export function getDataQualityScore(metrics) {
   if (metrics.totalPayments > 10) qualityScore += 25;
   if (metrics.uniqueCounterparties > 3) qualityScore += 25;
   if (metrics.assetDiversity > 1) qualityScore += 25;
-  if (metrics.totalPayments > 0) qualityScore += 25;
+  // Award the final 25 points only when there is BOTH payment activity
+  // AND counterparty diversity — the original code checked totalPayments > 0
+  // which is always true when totalPayments > 10 is already satisfied,
+  // making it impossible to ever score less than 50 via this path.
+  if (metrics.totalPayments > 0 && metrics.uniqueCounterparties > 0) qualityScore += 25;
 
   return {
     score: qualityScore,


### PR DESCRIPTION
## Summary

Two bugs fixed in `src/lib/lightweightRiskModel.js`:

### Bug 1 - Duplicate `totalPayments` check inflates quality score

`getDataQualityScore()` awarded 25 points for `totalPayments > 10` **and** another 25 points for `totalPayments > 0`. The second condition is always satisfied when the first is, so a wallet with >=10 payments can never score below 50/100 regardless of other data quality indicators (counterparties, asset diversity). The intent was to reward having *any* transactional activity alongside counterparty diversity. The last check has been changed to `totalPayments > 0 && uniqueCounterparties > 0` to reflect that intent.

### Bug 2 - No null guard in `calculateRiskScore()`

If `metrics` was `null` or `undefined`, the call would propagate into `normalizeFeatures()` and silently catch an error, falling through to `fallbackRiskCalculation({})` with no logged context. An explicit null check is now added at the top of `calculateRiskScore()` so callers get a clear error message.

## Files Changed
- `src/lib/lightweightRiskModel.js`
## Testing
- `getDataQualityScore({ totalPayments: 15, uniqueCounterparties: 0, assetDiversity: 0 })` should now return `score: 25` (not `50`).
- - `calculateRiskScore(null)` should log a clear error and return the fallback result.